### PR TITLE
Added SCC Output to caption-inspector

### DIFF
--- a/include/cc_data_output.h
+++ b/include/cc_data_output.h
@@ -23,6 +23,19 @@
 #include "pipeline_utils.h"
 
 /*----------------------------------------------------------------------------*/
+/*-- SCC Artifact Output ------------------------------------------------------*/
+/*----------------------------------------------------------------------------*/
+/* Emit one SCC file per EIA-608 field (Field 1 and Field 2). */
+#define SCC_FIELD1_EXT "F1.scc"
+#define SCC_FIELD2_EXT "F2.scc"
+
+/* Standard Scenarist SCC header */
+#define SCC_HEADER_TEXT "Scenarist_SCC V1.0\n\n"
+
+/* Buffer size for a packed SCC line (sequential-frame packed words). */
+#define SCC_MAX_LINE_CHARS 8192
+
+/*----------------------------------------------------------------------------*/
 /*--                               Constants                                --*/
 /*----------------------------------------------------------------------------*/
 #define UNKOWN_CHANNEL                                           0

--- a/include/context.h
+++ b/include/context.h
@@ -227,6 +227,17 @@ typedef struct {
     uint8 cea708Code;
     uint8 cea708BytesRemaining;
     char ccdFileName[MAX_FILE_NAME_LEN];
+
+    /* SCC artifacts (one file per EIA-608 field). */
+    FILE* sccFp[2];                      /* [0]=Field1, [1]=Field2 */
+    boolean sccHeaderWritten[2];
+    char sccFileName[2][MAX_FILE_NAME_LEN];
+
+    /* Sequential-frame packed SCC output per field. */
+    boolean sccHasPending[2];
+    uint32 sccLastFrame[2];
+    char sccPendingTc[2][24];            /* "HH:MM:SS:FF" */
+    char sccPendingWords[2][8192];       /* " hhhh hhhh ..." */
 } CcDataOutputCtx;
 
 typedef struct {

--- a/src/sink/cc_data_output.c
+++ b/src/sink/cc_data_output.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include <stdlib.h>
+#include <string.h>
 #include <time.h>
 
 #include "debug.h"
@@ -90,6 +91,22 @@ LinkInfo CcDataOutInitialize( Context* rootCtxPtr ) {
     ctxPtr->cea708BytesRemaining = 0;
     buildOutputPath(rootCtxPtr->config.inputFilename, rootCtxPtr->config.outputDirectory, "ccd", ctxPtr->ccdFileName);
 
+    /* SCC artifact initialization */
+    ctxPtr->sccFp[0] = NULL;
+    ctxPtr->sccFp[1] = NULL;
+    ctxPtr->sccHeaderWritten[0] = FALSE;
+    ctxPtr->sccHeaderWritten[1] = FALSE;
+    ctxPtr->sccHasPending[0] = FALSE;
+    ctxPtr->sccHasPending[1] = FALSE;
+    ctxPtr->sccLastFrame[0] = 0;
+    ctxPtr->sccLastFrame[1] = 0;
+    ctxPtr->sccPendingTc[0][0] = '\0';
+    ctxPtr->sccPendingTc[1][0] = '\0';
+    ctxPtr->sccPendingWords[0][0] = '\0';
+    ctxPtr->sccPendingWords[1][0] = '\0';
+    buildOutputPath(rootCtxPtr->config.inputFilename, rootCtxPtr->config.outputDirectory, SCC_FIELD1_EXT, ctxPtr->sccFileName[0]);
+    buildOutputPath(rootCtxPtr->config.inputFilename, rootCtxPtr->config.outputDirectory, SCC_FIELD2_EXT, ctxPtr->sccFileName[1]);
+
     LinkInfo linkInfo;
     linkInfo.linkType = CC_DATA___TEXT_FILE;
     linkInfo.sourceType = DATA_TYPE_CC_DATA;
@@ -121,6 +138,14 @@ uint8 CcDataOutProcNextBuffer( void* rootCtxPtr, Buffer* buffPtr ) {
     ASSERT(((Context*)rootCtxPtr)->ccDataOutputCtxPtr);
     CcDataOutputCtx* ctxPtr = ((Context*)rootCtxPtr)->ccDataOutputCtxPtr;
     int len;
+
+    Context* rctx = (Context*)rootCtxPtr;
+
+    /* SCC accumulation for this buffer (per field) */
+    char sccWords[2][SCC_MAX_LINE_CHARS];
+    boolean sccHasWords[2] = { FALSE, FALSE };
+    sccWords[0][0] = '\0';
+    sccWords[1][0] = '\0';
 
     if( ctxPtr->fp == NULL ) {
         LOG(DEBUG_LEVEL_INFO, DBG_CCD_OUT, "Creating new CCD File for Output: %s", ctxPtr->ccdFileName);
@@ -227,6 +252,18 @@ uint8 CcDataOutProcNextBuffer( void* rootCtxPtr, Buffer* buffPtr ) {
             } else {
                 sprintf(lineOut.element[lineOut.numElements].hexStr, "P%s:%02X%02X", ccTypeStr[ccType], ccData1, ccData2);
             }
+
+              /* SCC capture: valid 608 field words only */
+              if( (rctx->config.artifacts == TRUE) &&
+                  (ccType == CC_DATA_TYPE__FIELD_1 || ccType == CC_DATA_TYPE__FIELD_2) ) {
+                  uint16 w = (uint16)(((ccData1 & 0x7F) << 8) | (ccData2 & 0x7F));
+                  if( w != 0x0000 ) {
+                      char tmp[8];
+                      snprintf(tmp, sizeof(tmp), " %04x", (unsigned int)w);
+                      strncat(sccWords[ccType], tmp, (SCC_MAX_LINE_CHARS - strlen(sccWords[ccType]) - 1));
+                      sccHasWords[ccType] = TRUE;
+                  }
+              }
             switch( ccType ) {
                 case CC_DATA_TYPE__FIELD_1:
                 case CC_DATA_TYPE__FIELD_2:
@@ -305,6 +342,53 @@ uint8 CcDataOutProcNextBuffer( void* rootCtxPtr, Buffer* buffPtr ) {
     ASSERT(lineOut.numElements == 0 );
     writeToFile(ctxPtr->fp, "\n\n");
 
+    /* SCC emission (per field, sequential-frame packed) */
+    if( rctx->config.artifacts == TRUE ) {
+        CaptionTime ftc = buffPtr->captionTime;
+        uint32 frameNum = 0;
+        if( ftc.source == CAPTION_TIME_FRAME_NUMBERING ) {
+            frameNum = timeCodeToFrame(&ftc);
+        } else {
+            uint32 totalMs = (uint32)((((ftc.hour * 60u) + ftc.minute) * 60u + ftc.second) * 1000u + ftc.millisecond);
+            uint32 fps100 = ftc.frameRatePerSecTimesOneHundred;
+            frameNum = (uint32)(((uint64)totalMs * (uint64)fps100 + 50000u) / 100000u);
+            memset(&ftc, 0, sizeof(CaptionTime));
+            ftc.frameRatePerSecTimesOneHundred = buffPtr->captionTime.frameRatePerSecTimesOneHundred;
+            ftc.dropframe = buffPtr->captionTime.dropframe;
+            ftc.source = CAPTION_TIME_FRAME_NUMBERING;
+            frameToTimeCode(frameNum, ftc.frameRatePerSecTimesOneHundred, &ftc);
+        }
+        char tcStr[24];
+        snprintf(tcStr, sizeof(tcStr), "%02d:%02d:%02d:%02d", ftc.hour, ftc.minute, ftc.second, ftc.frame);
+        for( uint8 f = 0; f < 2; f++ ) {
+            if( sccHasWords[f] == FALSE ) continue;
+            if( ctxPtr->sccFp[f] == NULL ) {
+                ctxPtr->sccFp[f] = fileOutputInit(ctxPtr->sccFileName[f]);
+                writeToFile(ctxPtr->sccFp[f], "%s", SCC_HEADER_TEXT);
+                ctxPtr->sccHeaderWritten[f] = TRUE;
+            }
+            if( ctxPtr->sccHasPending[f] == FALSE ) {
+                strncpy(ctxPtr->sccPendingTc[f], tcStr, sizeof(ctxPtr->sccPendingTc[f]) - 1);
+                ctxPtr->sccPendingTc[f][sizeof(ctxPtr->sccPendingTc[f]) - 1] = '\0';
+                strncpy(ctxPtr->sccPendingWords[f], sccWords[f], sizeof(ctxPtr->sccPendingWords[f]) - 1);
+                ctxPtr->sccPendingWords[f][sizeof(ctxPtr->sccPendingWords[f]) - 1] = '\0';
+                ctxPtr->sccHasPending[f] = TRUE;
+                ctxPtr->sccLastFrame[f] = frameNum;
+            } else if( frameNum == (ctxPtr->sccLastFrame[f] + 1) ) {
+                strncat(ctxPtr->sccPendingWords[f], sccWords[f], sizeof(ctxPtr->sccPendingWords[f]) - strlen(ctxPtr->sccPendingWords[f]) - 1);
+                ctxPtr->sccLastFrame[f] = frameNum;
+            } else {
+                writeToFile(ctxPtr->sccFp[f], "%s%s\n", ctxPtr->sccPendingTc[f], ctxPtr->sccPendingWords[f]);
+                strncpy(ctxPtr->sccPendingTc[f], tcStr, sizeof(ctxPtr->sccPendingTc[f]) - 1);
+                ctxPtr->sccPendingTc[f][sizeof(ctxPtr->sccPendingTc[f]) - 1] = '\0';
+                strncpy(ctxPtr->sccPendingWords[f], sccWords[f], sizeof(ctxPtr->sccPendingWords[f]) - 1);
+                ctxPtr->sccPendingWords[f][sizeof(ctxPtr->sccPendingWords[f]) - 1] = '\0';
+                ctxPtr->sccHasPending[f] = TRUE;
+                ctxPtr->sccLastFrame[f] = frameNum;
+            }
+        }
+    }
+
     FreeBuffer(buffPtr);
     return PIPELINE_SUCCESS;
 } // CcDataOutProcNextBuffer()
@@ -330,9 +414,25 @@ uint8 CcDataOutShutdown( void* rootCtxPtr ) {
     ASSERT(rootCtxPtr);
     ASSERT(((Context*)rootCtxPtr)->ccDataOutputCtxPtr);
 
-    closeFile(((Context*)rootCtxPtr)->ccDataOutputCtxPtr->fp);
+    CcDataOutputCtx* ctxPtr = ((Context*)rootCtxPtr)->ccDataOutputCtxPtr;
 
-    free(((Context*)rootCtxPtr)->ccDataOutputCtxPtr);
+    /* Flush pending SCC lines and close SCC files */
+    for( uint8 f = 0; f < 2; f++ ) {
+        if( ctxPtr->sccHasPending[f] == TRUE && ctxPtr->sccFp[f] != NULL ) {
+            writeToFile(ctxPtr->sccFp[f], "%s%s\n", ctxPtr->sccPendingTc[f], ctxPtr->sccPendingWords[f]);
+            ctxPtr->sccHasPending[f] = FALSE;
+            ctxPtr->sccPendingTc[f][0] = '\0';
+            ctxPtr->sccPendingWords[f][0] = '\0';
+        }
+        if( ctxPtr->sccFp[f] != NULL ) {
+            closeFile(ctxPtr->sccFp[f]);
+            ctxPtr->sccFp[f] = NULL;
+        }
+    }
+
+    closeFile(ctxPtr->fp);
+
+    free(ctxPtr);
     ((Context*)rootCtxPtr)->ccDataOutputCtxPtr = NULL;
     return PIPELINE_SUCCESS;
 } // CcDataOutShutdown()


### PR DESCRIPTION
### Added Naive SCC output to caption-inspector

If you find this, use at your own peril.

Creates two new output files...
- *.F1.scc = Field 1  # Filename should probably be -F1.scc
- *.F2.scc = Field 2

Disclosure: Assisted by Slop-LLM(TM)

### Compile (macOS, Apple Silicon, using FFmpeg 4

```shell
$ brew install ffmpeg@4
$ git clone [path to wherever you find this fork of caption-inspector]
$ cd caption-inspector
$ export CPATH="/opt/homebrew/opt/ffmpeg@4/include" 
$ export LIBRARY_PATH="/opt/homebrew/opt/ffmpeg@4/lib"
$ make caption-inspector
```

### Test Case

```shell
$ curl --request GET "http://ncamftp.wgbh.org/DTV/CEA%20test%20material/Iteration_1/CEAv1.2zero.trp" -o "./CEAv1.2zero.trp"
$ ffmpeg -hide_banner -an -sn -dn -i "./CEAv1.2zero.trp" -map 0:v:0 -codec:v 'copy' "./CEAv1.2zero.ts"
$ ffmpeg -hide_banner -an -sn -dn -i "./CEAv1.2zero.trp" -map 0:v:0 -codec:v 'copy' "./CEAv1.2zero.remuxed.ts"

$ ln -s /opt/homebrew/bin/mediainfo /usr/local/bin/mediainfo

$ mkdir -p ${TMPDIR%/}/test
$ ./caption-inspector --output "${TMPDIR%/}/test" "./CEAv1.2zero.remuxed.ts"
```
```
$ ls -1 "${TMPDIR%/}/test"
CEAv1.2zero.remuxed-C1.608
CEAv1.2zero.remuxed-C2.608
CEAv1.2zero.remuxed-C3.608
CEAv1.2zero.remuxed-C4.608
CEAv1.2zero.remuxed-S1.708
CEAv1.2zero.remuxed-S2.708
CEAv1.2zero.remuxed.ccd
CEAv1.2zero.remuxed.dbg
CEAv1.2zero.remuxed.F1.scc <<<<<<<<<<<<<<<< New file
CEAv1.2zero.remuxed.F2.scc <<<<<<<<<<<<<<<< New file
CEAv1.2zero.remuxed.inf
CEAv1.2zero.remuxed.mcc
```

```text
$ head -n10 "${TMPDIR%/}/test/CEAv1.2zero.remuxed.F1.scc"
Scenarist_SCC V1.0

00:00:04:04 142c 1c20 1c2c
00:00:04:21 1420 1374 1721 5465 7374 2043 6170 7469 6f6e 7300 1450 1721 4454 5620 4163 6365 7373 2050 726f 6a65 6374 2c20 5747 4248 2d4e 4341 4d00 1470 1723 2872 756e 6e69 6e67 2074 696d 653a 2034 206d 696e 2e20 3135 2073 6563 2e29 142c 142f
00:00:08:00 1c20 1c50 2843 4332 2920 5468 6973 2064 6174 6120 6973 1c70 696e 2043 6170 7469 6f6e 2043 6861 6e6e 656c 2032 1c2c
00:00:09:01 1c2c 1c2f
00:00:13:09 1420 1370 2843 4331 2946 4343 2039 312d 3131 3900 1450 5461 626c 6520 6f66 2053 7461 6e64 6172 6420 4368 6172 6163 7465 7273 3a00 1470 2021 2223 2425 2627 2829 2a2b 2c2d 2e2f 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f 142c
00:00:15:01 142c 142f
00:00:18:00 1c20 1c50 2843 4332 2920 5468 6973 2064 6174 6120 6973 1c70 696e 2043 6170 7469 6f6e 2043 6861 6e6e 656c 2032 1c2c
00:00:19:01 1c2c 1c2f
```

```text
$ head -n10 "${TMPDIR%/}/test/CEAv1.2zero.remuxed.F2.scc"

Scenarist_SCC V1.0

00:00:04:03 152c 1d20 1d2c
00:00:04:20 1520 1374 1721 5465 7374 2043 6170 7469 6f6e 7300 1450 1721 4454 5620 4163 6365 7373 2050 726f 6a65 6374 2c20 5747 4248 2d4e 4341 4d00 1470 1723 2872 756e 6e69 6e67 2074 696d 653a 2034 206d 696e 2e20 3135 2073 6563 2e29 152c 152f
00:00:07:29 1d20 1c50 2843 4334 2920 5468 6973 2064 6174 6120 6973 1c70 696e 2043 6170 7469 6f6e 2043 6861 6e6e 656c 2034 1d2c
00:00:09:00 1d2c 1d2f
00:00:13:08 1520 1370 2843 4333 2946 4343 2039 312d 3131 3900 1450 5461 626c 6520 6f66 2053 7461 6e64 6172 6420 4368 6172 6163 7465 7273 3a00 1470 2021 2223 2425 2627 2829 2a2b 2c2d 2e2f 3031 3233 3435 3637 3839 3a3b 3c3d 3e3f 152c
00:00:15:00 152c 152f
00:00:17:29 1d20 1c50 2843 4334 2920 5468 6973 2064 6174 6120 6973 1c70 696e 2043 6170 7469 6f6e 2043 6861 6e6e 656c 2034 1d2c
00:00:19:00 1d2c 1d2f
```

```text
$ ccasdi "${TMPDIR%/}/test/CEAv1.2zero.remuxed.F1.scc" "${TMPDIR%/}/test/CEAv1.2zero.remuxed.F1.ccd"

$ head -n20 "${TMPDIR%/}/test/CEAv1.2zero.remuxed.F1.ccd"

SCC_disassembly V1.2.1(UTF-8)
CHANNEL 3

CHANNEL 1
00:00:04:04	{EDM}{RCL}{EDM}
00:00:04:21	{RCL}{1308}{TO1}Test Captions_{1400}{TO1}DTV Access Project, WGBH-NCAM_{1500}{TO3}(running time: 4 min. 15 sec.){EDM}{EOC}

CHANNEL 2
00:00:08:00	{RCL}{1400}(CC2) This data is{1500}in Caption Channel 2{EDM}
00:00:09:01	{EDM}{EOC}

CHANNEL 1
00:00:13:09	{RCL}{1300}(CC1)FCC 91-119_{1400}Table of Standard Characters:_{1500} !"#$%&'()á+,-./0123456789:;<=>?{EDM}
00:00:15:01	{EDM}{EOC}

CHANNEL 2
00:00:18:00	{RCL}{1400}(CC2) This data is{1500}in Caption Channel 2{EDM}
00:00:19:01	{EDM}{EOC}
```
